### PR TITLE
Correct array bounds creating centeredEntries from entries

### DIFF
--- a/Source/Charts/Renderers/XAxisRenderer.swift
+++ b/Source/Charts/Renderers/XAxisRenderer.swift
@@ -145,7 +145,7 @@ open class XAxisRenderer: NSObject, AxisRenderer
         if axis.centerAxisLabelsEnabled
         {
             let offset: Double = interval / 2.0
-            axis.centeredEntries = axis.entries[..<n]
+            axis.centeredEntries = axis.entries
                 .map { $0 + offset }
         }
         


### PR DESCRIPTION
### Issue Link :link:
https://github.com/ChartsOrg/Charts/issues/4992
raised Dec 2022 but still not fixed in original repository many releases later

### Goals :soccer:
Prevent crash if isCenteringEnabled is true, where drawLabels requires same number of entires and centeredEntries

### Implementation Details :construction:
Take the fix from the issue 

### Testing Details :mag:
Beat up the whitelabel, lots of changes of number of periods etc